### PR TITLE
default onSelect handler compares option innerText with result.name, …

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ function openregisterLocationPicker (opts) {
   opts.minLength = opts.minLength || 2
 
   opts.onSelect = opts.onSelect || ((result) => {
-    var requestedOption = Array.prototype.filter.call(opts.selectElement.options, o => o.innerHTML === result && result.name)[0]
+    var requestedOption = Array.prototype.filter.call(opts.selectElement.options, o => o.innerText === result.name)[0]
     if (requestedOption) { requestedOption.selected = true }
   })
 

--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ function openregisterLocationPicker (opts) {
   opts.minLength = opts.minLength || 2
 
   opts.onSelect = opts.onSelect || ((result) => {
-    var requestedOption = Array.prototype.filter.call(opts.selectElement.options, o.innerText === (result && result.name))[0]
+    var requestedOption = Array.prototype.filter.call(opts.selectElement.options, o => o.innerText === (result && result.name))[0]
     if (requestedOption) { requestedOption.selected = true }
   })
 

--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ function openregisterLocationPicker (opts) {
   opts.minLength = opts.minLength || 2
 
   opts.onSelect = opts.onSelect || ((result) => {
-    var requestedOption = Array.prototype.filter.call(opts.selectElement.options, o => o.innerText === result.name)[0]
+    var requestedOption = Array.prototype.filter.call(opts.selectElement.options, o.innerText === (result && result.name))[0]
     if (requestedOption) { requestedOption.selected = true }
   })
 


### PR DESCRIPTION
With a select like this...

```
<select name="response" id="openregister-picker">
    <option value="territory:AE-AJ">Ajman</option>
    <option value="territory:AS">American Samoa</option>
    ....other options....
</select>
```

...and initialisation like this...

```
var openregisterPicker = document.querySelector('#openregister-picker');
if(!!openregisterPicker) {
  openregisterLocationPicker({
    selectElement: openregisterPicker,
    url: openregisterPicker.dataset.graph
  });
}

```
...nothing is selected when i choose an option.

This changes the default onSelect handler to fix this.