### PR TITLE
Add support for custom entries and synonyms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 _(add items here for easier creation of next log entry)_
 
+- [Feature] Add support for custom entries and synonyms.
+
 ## 0.3.0 - 2017-07-11
 
 - Use `accessible-autocomplete@v1.4.1`.

--- a/README.md
+++ b/README.md
@@ -93,13 +93,16 @@ This will render the same `<select>` menu as before on the server, but hides it 
 
 [If you prefer to learn by reading the source, try out the example.](https://alphagov.github.io/openregister-location-picker/examples/)
 
-### Adding additional synonyms
+### Adding additional entries and synonyms
 
-You can pass in custom synonyms using the [`additionalSynonyms` option](https://github.com/alphagov/openregister-picker-engine#optionsadditionalsynonyms):
+You can pass in custom entries and synonyms using the [`additionalEntries` and `additionalSynonyms` option](https://github.com/alphagov/openregister-picker-engine#optionsadditionalentries):
 
 ```html
 <script type="text/javascript">
   openregisterLocationPicker({
+    additionalEntries: [
+      { name: 'Atlantis', code: 'country:AN' }
+    ],
     additionalSynonyms: [
       { name: 'Albion', code: 'country:GB' }
     ],

--- a/README.md
+++ b/README.md
@@ -93,6 +93,31 @@ This will render the same `<select>` menu as before on the server, but hides it 
 
 [If you prefer to learn by reading the source, try out the example.](https://alphagov.github.io/openregister-location-picker/examples/)
 
+### Adding additional synonyms
+
+You can pass in custom synonyms using the [`additionalSynonyms` option](https://github.com/alphagov/openregister-picker-engine#optionsadditionalsynonyms):
+
+```html
+<script type="text/javascript">
+  openregisterLocationPicker({
+    additionalSynonyms: [
+      { name: 'Albion', code: 'country:GB' }
+    ],
+    selectElement: document.getElementById('location-picker'),
+    url: '/assets/location-picker-graph.json'
+  })
+</script>
+```
+
+You can additionally specify custom synonyms on the `<option>` elements by using the `data-additional-synonyms` attribute:
+
+```html
+<select id="location-picker">
+  <option value="territory:GB" data-additional-synonyms='["Blighty"]'>United Kingdom</option>
+  <option value="country:RO" data-additional-synonyms='["Dacia"]'>Romania</option>
+</select>
+```
+
 ## Keep the data up to date
 
 Government Digital Service will publish new versions of the `openregister-location-picker` package when the data changes, such as when countries are renamed.

--- a/examples/index.html
+++ b/examples/index.html
@@ -257,7 +257,7 @@
           <option value="territory:PR">Puerto Rico</option>
           <option value="country:QA">Qatar</option>
           <option value="territory:AE-RK">Ras al-Khaimah</option>
-          <option value="country:RO">Romania</option>
+          <option value="country:RO" data-additional-synonyms='["Dacia"]'>Romania</option>
           <option value="country:RU">Russia</option>
           <option value="country:RW">Rwanda</option>
           <option value="territory:RE">Réunion</option>
@@ -342,6 +342,9 @@
     <script type="text/javascript" src="../dist/location-picker.min.js"></script>
     <script type="text/javascript">
       openregisterLocationPicker({
+        additionalSynonyms: [
+          { name: 'Albion', code: 'country:GB' }
+        ],
         defaultValue: '',
         selectElement: document.getElementById('default'),
         url: '../dist/location-picker-graph.json'

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "accessible-autocomplete": "^1.4.1",
-    "openregister-picker-engine": "^1.1.0"
+    "openregister-picker-engine": "^1.2.0"
   },
   "devDependencies": {
     "babel-core": "^6.24.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "accessible-autocomplete": "^1.4.1",
-    "openregister-picker-engine": "^1.0.0"
+    "openregister-picker-engine": "^1.1.0"
   },
   "devDependencies": {
     "babel-core": "^6.24.1",

--- a/src/index.js
+++ b/src/index.js
@@ -29,20 +29,24 @@ function openregisterLocationPicker (opts) {
     var requestedOption = Array.prototype.filter.call(opts.selectElement.options, o => o.innerText === (result && result.name))[0]
     if (requestedOption) { requestedOption.selected = true }
   })
-  
+
   const optionsWithAdditionalSynonyms = Array.prototype
     .filter.call(opts.selectElement.options, option => option.dataset && option.dataset.additionalSynonyms)
   const htmlAdditionalSynonyms = optionsWithAdditionalSynonyms
+    // => [<HtmlOption value="country:GB" data-additional-synonyms="['Albion', 'Blighty']">, ...]
     .map(option => ({ code: option.value, synonyms: option.dataset.additionalSynonyms }))
-    .reduce((allSynonyms, currentSet) => {
-      const moreSynonyms = JSON.parse(currentSet.synonyms)
-        .map(synonymName => ({ name: synonymName, code: currentSet.code }))
-      return allSynonyms.concat(moreSynonyms)
+    // => [{ code: 'country:GB', synonyms: "['Albion', 'Blighty']" }, ...]
+    .reduce((additionalSynonymsArray, additionalSynonymsSet) => {
+      const additionalSynonymsSeparated = JSON.parse(additionalSynonymsSet.synonyms)
+        .map(synonymName => ({ name: synonymName, code: additionalSynonymsSet.code }))
+      return additionalSynonymsArray.concat(additionalSynonymsSeparated)
     }, [])
+    // => [{ code: 'country:GB', name: 'Albion' }, { code: 'country:GB', name: 'Blighty' }, ...]
 
   opts.additionalSynonyms = (opts.additionalSynonyms || []).concat(htmlAdditionalSynonyms)
 
   opts.source = opts.source || openregisterPickerEngine({
+    additionalEntries: opts.additionalEntries,
     additionalSynonyms: opts.additionalSynonyms,
     url: opts.url,
     fallback: opts.fallback

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ function suggestionTemplate (result) {
 function openregisterLocationPicker (opts) {
   // Set defaults.
   opts.fallback = opts.fallback || ((query, syncResults) => {
-    const availableOptions = Array.prototype.map.call(opts.selectElement.options, o => o.innerHTML)
+    const availableOptions = Array.prototype.map.call(opts.selectElement.options, o => o.innerText)
     const filteredResults = query
       ? availableOptions.filter(r => r.toLowerCase().indexOf(query.toLowerCase()) !== -1)
       : []
@@ -29,8 +29,24 @@ function openregisterLocationPicker (opts) {
     var requestedOption = Array.prototype.filter.call(opts.selectElement.options, o => o.innerText === (result && result.name))[0]
     if (requestedOption) { requestedOption.selected = true }
   })
+  
+  const optionsWithAdditionalSynonyms = Array.prototype
+    .filter.call(opts.selectElement.options, option => option.dataset && option.dataset.additionalSynonyms)
+  const htmlAdditionalSynonyms = optionsWithAdditionalSynonyms
+    .map(option => ({ code: option.value, synonyms: option.dataset.additionalSynonyms }))
+    .reduce((allSynonyms, currentSet) => {
+      const moreSynonyms = JSON.parse(currentSet.synonyms)
+        .map(synonymName => ({ name: synonymName, code: currentSet.code }))
+      return allSynonyms.concat(moreSynonyms)
+    }, [])
 
-  opts.source = opts.source || openregisterPickerEngine({ url: opts.url, fallback: opts.fallback })
+  opts.additionalSynonyms = (opts.additionalSynonyms || []).concat(htmlAdditionalSynonyms)
+
+  opts.source = opts.source || openregisterPickerEngine({
+    additionalSynonyms: opts.additionalSynonyms,
+    url: opts.url,
+    fallback: opts.fallback
+  })
 
   opts.templates = opts.templates || {
     inputValue: inputValueTemplate,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2064,9 +2064,9 @@ once@^1.3.0, once@^1.3.3:
   dependencies:
     wrappy "1"
 
-openregister-picker-engine@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/openregister-picker-engine/-/openregister-picker-engine-1.0.0.tgz#d0bc75765fd9a8cac256e2ac5d1043f99f68106f"
+openregister-picker-engine@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/openregister-picker-engine/-/openregister-picker-engine-1.1.0.tgz#1bbbd73f8d30113ec8268e2089e25e4f5fb40dcc"
   dependencies:
     corejs-typeahead "^1.1.1"
     whatwg-fetch "^2.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2064,9 +2064,9 @@ once@^1.3.0, once@^1.3.3:
   dependencies:
     wrappy "1"
 
-openregister-picker-engine@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/openregister-picker-engine/-/openregister-picker-engine-1.1.0.tgz#1bbbd73f8d30113ec8268e2089e25e4f5fb40dcc"
+openregister-picker-engine@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/openregister-picker-engine/-/openregister-picker-engine-1.2.0.tgz#078243b6fd084dc3b87970c3aba0a7c3943a5bcf"
   dependencies:
     corejs-typeahead "^1.1.1"
     whatwg-fetch "^2.0.3"


### PR DESCRIPTION
- Pass in `additionalEntries` and `additionalSynonyms` argument to `openregister-picker-engine`
- Pick up other synonyms from the list of options in the progressively enhanced select